### PR TITLE
chore: add OSS release files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: 'bug: '
+labels: bug
+---
+
+## Describe the Bug
+A clear description of what the bug is.
+
+## To Reproduce
+Steps to reproduce:
+1. Apply manifest '...'
+2. Run command '...'
+3. See error
+
+## Expected Behavior
+What you expected to happen.
+
+## Environment
+- Kubernetes version: 
+- Operator version/image: 
+- Helm chart version: 
+- Cloud provider / distro: 
+
+## Logs
+```
+Paste relevant operator logs here
+```
+
+## Additional Context
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request
+about: Suggest a new feature
+title: 'feat: '
+labels: enhancement
+---
+
+## Problem
+What problem does this solve?
+
+## Proposed Solution
+Describe the feature you'd like.
+
+## Alternatives Considered
+Any alternative approaches you've considered.
+
+## Additional Context
+Any other context, diagrams, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## What
+
+Brief description of changes.
+
+## Why
+
+What problem does this solve? Link to issue if applicable.
+
+Closes #
+
+## How
+
+Key implementation details.
+
+## Testing
+
+- [ ] Unit tests added/updated
+- [ ] `make test` passes
+- [ ] `make manifests generate` run (if CRD changes)
+- [ ] Manual testing done (describe below)
+
+## Checklist
+
+- [ ] Code follows project conventions
+- [ ] Documentation updated (if applicable)
+- [ ] No breaking CRD changes (or migration path documented)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,52 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at **derek.mackley@hotmail.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to Round Table
+
+Thanks for your interest in contributing! 🏰
+
+## Getting Started
+
+1. **Fork** the repository
+2. **Clone** your fork: `git clone https://github.com/YOUR_USER/roundtable.git`
+3. **Create a branch**: `git checkout -b feat/your-feature`
+4. **Make changes** and write tests
+5. **Submit a PR** against `main`
+
+## Development Setup
+
+### Prerequisites
+
+- Go 1.26+
+- Docker
+- kubectl + a Kubernetes cluster (kind, minikube, etc.)
+- [kubebuilder](https://book.kubebuilder.io/) (for CRD generation)
+- NATS CLI (`nats`) — optional, for debugging
+
+### Build & Test
+
+```bash
+# Build the operator
+make build
+
+# Run tests
+make test
+
+# Generate CRDs after type changes
+make manifests generate
+
+# Run locally against a cluster
+make run
+
+# Build Docker image
+make docker-build IMG=roundtable-operator:dev
+```
+
+### Helm Chart
+
+```bash
+# Install from local chart
+helm install roundtable charts/roundtable-operator \
+  --namespace roundtable --create-namespace
+
+# Upgrade
+helm upgrade roundtable charts/roundtable-operator \
+  --namespace roundtable
+```
+
+## What to Work On
+
+- Check [open issues](https://github.com/dapperdivers/roundtable/issues) — look for `good first issue` labels
+- Bug fixes are always welcome
+- Feature ideas? Open an issue first to discuss
+
+## Code Style
+
+- Follow standard Go conventions (`gofmt`, `go vet`)
+- Write tests for new functionality
+- Keep CRD types well-documented with `// +kubebuilder` markers
+- Use structured logging (`logf.FromContext(ctx)`)
+
+## CRD Changes
+
+When modifying types in `api/v1alpha1/`:
+
+1. Update the Go types
+2. Run `make manifests generate` to regenerate CRDs and DeepCopy
+3. Update Helm chart CRDs: `cp config/crd/bases/* charts/roundtable-operator/crds/`
+4. Bump chart version in `Chart.yaml`
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add warm pool support for instant mission assembly
+fix: prevent race condition in warm knight claiming
+docs: add architecture overview
+test: add chain controller integration tests
+chore: bump Go to 1.26
+```
+
+## Pull Requests
+
+- Keep PRs focused — one feature or fix per PR
+- Include tests
+- Update documentation if behavior changes
+- Link related issues
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 dapperdivers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.8.x   | ✅ Current         |
+| < 0.8   | ❌ Not supported   |
+
+## Reporting a Vulnerability
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, report them via email to: **derek.mackley@hotmail.com**
+
+Please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+You should receive an initial response within **48 hours**. We will work with you to understand and address the issue before any public disclosure.
+
+## Security Considerations
+
+Round Table manages AI agents as Kubernetes pods. Key security areas:
+
+- **Pod isolation** — Knights run with restricted SecurityContexts and NetworkPolicies
+- **NATS authentication** — JetStream consumers use per-knight credentials
+- **Secret management** — Secrets are injected via ExternalSecrets/envFrom, never stored in CRDs
+- **RBAC** — Operator uses least-privilege ClusterRole; knights get namespace-scoped ServiceAccounts
+- **Ephemeral missions** — Auto-cleanup prevents resource leaks and reduces attack surface
+
+## Disclosure Policy
+
+- We follow [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure)
+- Fixes are released as patch versions
+- CVEs are filed when applicable
+- Credit is given to reporters (unless anonymity is requested)


### PR DESCRIPTION
## Open Source Release Preparation

Adds standard OSS files required for public release:

- **LICENSE** — Apache 2.0
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **SECURITY.md** — Vulnerability disclosure policy
- **CONTRIBUTING.md** — Development setup and guidelines
- **Issue templates** — Bug report and feature request
- **PR template** — Standardized pull request format

Part of the Round Table ecosystem release prep.