### PR TITLE
fix: don't clobber inherited TMPDIR during Nix bootstrap

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -99,15 +99,19 @@ EOF
     return 1
   fi
 
-  TMPDIR=$(mktemp -d)
+  # Local var, NOT TMPDIR: overwriting the inherited TMPDIR (set to
+  # /data/scratch) and then rm-ing it below leaves later mktemp calls (Phase 3)
+  # pointing at a deleted base dir, which crashloops the pod.
+  local installer_tmp
+  installer_tmp=$(mktemp -d)
   log "  Extracting installer..."
-  tar xf "$CACHE_TAR" -C "$TMPDIR"
+  tar xf "$CACHE_TAR" -C "$installer_tmp"
 
   # The tarball extracts to nix-<version>-<arch>/ with a store/ directory
-  INSTALLER_DIR=$(find "$TMPDIR" -maxdepth 1 -name 'nix-*' -type d | head -1)
+  INSTALLER_DIR=$(find "$installer_tmp" -maxdepth 1 -name 'nix-*' -type d | head -1)
   if [ -z "$INSTALLER_DIR" ] || [ ! -d "$INSTALLER_DIR/store" ]; then
-    log "  ERROR: Unexpected installer layout in $TMPDIR"
-    ls -la "$TMPDIR"
+    log "  ERROR: Unexpected installer layout in $installer_tmp"
+    ls -la "$installer_tmp"
     return 1
   fi
 
@@ -138,7 +142,7 @@ EOF
   # Register the profile
   ln -sfn "$NIX_PROFILE" /nix/var/nix/profiles/per-user/node/profile
 
-  rm -rf "$TMPDIR"
+  rm -rf "$installer_tmp"
 
   # Mark as bootstrapped
   touch /nix/.bootstrapped


### PR DESCRIPTION
## Problem

`bootstrap_nix` did `TMPDIR=$(mktemp -d)` and later `rm -rf "$TMPDIR"`. The pod runs with `TMPDIR=/data/scratch` in its env, so this **overwrote the inherited `TMPDIR`** with an installer scratch dir and then deleted it. Every subsequent `mktemp -d` — notably the Phase 3 flake build (`BUILD_DIR=$(mktemp -d)`) — then resolved its base directory from the now-deleted `$TMPDIR` and failed:

```
mktemp: failed to create directory via template '/data/scratch/tmp.NiVglJ4hjE/tmp.XXXXXXXXXX': No such file or directory
```

Under `set -eo pipefail` that exits the entrypoint and crashloops the pod.

This only fires when `bootstrap_nix` runs, which happens on every boot for any knight whose `/nix` PVC has a broken profile symlink (the "Profile symlink broken — re-bootstrapping" path). In production `agravain` logged **200 restarts over 17h** stuck in `Provisioning`.

## Fix

Use a local `installer_tmp` variable for the installer scratch dir so the inherited `TMPDIR` survives intact for the rest of the script. No behavior change beyond not polluting `TMPDIR`.

## Testing

- `bash -n scripts/entrypoint.sh` passes
- All `$TMPDIR` references inside `bootstrap_nix` now use the local var; Phase 3 again resolves `mktemp` against the valid inherited `/data/scratch`

Note: agravain's existing `/nix` PVC is separately corrupted (broken profile symlink forcing re-bootstrap); with this fix the re-bootstrap completes instead of looping, but that PVC may still warrant a one-time wipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)