### PR TITLE
feat: shared Nix store builder script + read-only store support

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -74,110 +74,36 @@ fi
 # ──────────────────────────────────────────────────────────────────
 # Phase 2: Nix bootstrap (first boot only)
 # ──────────────────────────────────────────────────────────────────
+# Three modes:
+#   - /nix read-only  → shared store; tools prebuilt by the operator's build
+#     Job. Skip bootstrap/build, just source the per-knight profile.
+#   - /nix writable   → per-pod PVC store (legacy). Bootstrap + build locally.
+#   - no /nix         → skip Nix entirely.
 NIX_PROFILE="$HOME/.nix-profile"
-NIX_CONF="/nix/etc/nix/nix.conf"
+NIX_SHARED_STORE="false"
 
-bootstrap_nix() {
-  log "Phase 2: Installing Nix to PVC (first boot)..."
+# shellcheck source=scripts/nix-lib.sh
+. /app/scripts/nix-lib.sh
 
-  # Create directory structure Nix expects
-  mkdir -p /nix/store /nix/var/nix/profiles/per-user/node \
-           /nix/var/nix/gcroots/per-user/node /nix/etc/nix
-
-  # Write nix.conf for single-user mode with flakes
-  cat > "$NIX_CONF" <<'EOF'
-build-users-group =
-experimental-features = nix-command flakes
-sandbox = false
-max-jobs = auto
-EOF
-
-  # Extract cached installer tarball
-  CACHE_TAR=$(ls /opt/nix-cache/nix-*.tar.xz 2>/dev/null | head -1)
-  if [ -z "$CACHE_TAR" ]; then
-    log "  ERROR: No cached Nix installer found"
-    return 1
-  fi
-
-  # Local var, NOT TMPDIR: overwriting the inherited TMPDIR (set to
-  # /data/scratch) and then rm-ing it below leaves later mktemp calls (Phase 3)
-  # pointing at a deleted base dir, which crashloops the pod.
-  local installer_tmp
-  installer_tmp=$(mktemp -d)
-  log "  Extracting installer..."
-  tar xf "$CACHE_TAR" -C "$installer_tmp"
-
-  # The tarball extracts to nix-<version>-<arch>/ with a store/ directory
-  INSTALLER_DIR=$(find "$installer_tmp" -maxdepth 1 -name 'nix-*' -type d | head -1)
-  if [ -z "$INSTALLER_DIR" ] || [ ! -d "$INSTALLER_DIR/store" ]; then
-    log "  ERROR: Unexpected installer layout in $installer_tmp"
-    ls -la "$installer_tmp"
-    return 1
-  fi
-
-  # Copy store paths from the installer
-  log "  Copying store paths..."
-  cp -a "$INSTALLER_DIR/store/"* /nix/store/
-
-  # Find the nix binary and create profile links
-  NIX_STORE_PATH=$(find /nix/store -maxdepth 1 -name '*-nix-*' -type d | grep -v '\.drv$' | head -1)
-  if [ -z "$NIX_STORE_PATH" ] || [ ! -x "$NIX_STORE_PATH/bin/nix" ]; then
-    # Try harder — look for the actual binary
-    NIX_STORE_PATH=$(find /nix/store -name 'nix' -executable -path '*/bin/nix' -printf '%h/..\n' 2>/dev/null | head -1)
-    NIX_STORE_PATH=$(cd "$NIX_STORE_PATH" 2>/dev/null && pwd)
-  fi
-
-  if [ -z "$NIX_STORE_PATH" ] || [ ! -x "$NIX_STORE_PATH/bin/nix" ]; then
-    log "  ERROR: Could not find nix binary in store"
-    find /nix/store -name 'nix' -executable 2>/dev/null | head -5
-    return 1
-  fi
-
-  log "  Nix store path: $NIX_STORE_PATH"
-
-  # Create profile symlink
-  mkdir -p "$(dirname "$NIX_PROFILE")"
-  ln -sfn "$NIX_STORE_PATH" "$NIX_PROFILE"
-
-  # Register the profile
-  ln -sfn "$NIX_PROFILE" /nix/var/nix/profiles/per-user/node/profile
-
-  rm -rf "$installer_tmp"
-
-  # Mark as bootstrapped
-  touch /nix/.bootstrapped
-  log "  Nix installed ✓ ($(du -sh /nix/store | cut -f1))"
-}
-
-if [ -d /nix ] && [ -w /nix ]; then
-  if [ ! -f /nix/.bootstrapped ]; then
-    bootstrap_nix
+if [ -d /nix ] && [ ! -w /nix ]; then
+  # Shared read-only store — tools come from the operator-published profile.
+  NIX_SHARED_STORE="true"
+  KNIGHT_NIX_PROFILE="${KNIGHT_NIX_PROFILE:-/nix/var/nix/profiles/knights/$(echo "${KNIGHT_NAME:-}" | tr '[:upper:]' '[:lower:]')}"
+  if [ -d "$KNIGHT_NIX_PROFILE/bin" ]; then
+    export PATH="$KNIGHT_NIX_PROFILE/bin:$PATH"
+    export NIX_CONF_DIR="/nix/etc/nix"
+    log "Phase 2: Shared Nix store (read-only) — profile $KNIGHT_NIX_PROFILE ✓"
   else
-    log "Phase 2: Nix already bootstrapped ✓"
-    # Restore profile symlink if missing (stale PVC / domain change)
-    if [ ! -d "$NIX_PROFILE/bin" ]; then
-      log "  Profile symlink broken — restoring..."
-      NIX_STORE_PATH=$(find /nix/store -maxdepth 1 -name '*-nix-*' -type d 2>/dev/null | grep -v '\.drv$' | head -1)
-      if [ -n "$NIX_STORE_PATH" ] && [ -x "$NIX_STORE_PATH/bin/nix" ]; then
-        mkdir -p "$(dirname "$NIX_PROFILE")"
-        ln -sfn "$NIX_STORE_PATH" "$NIX_PROFILE"
-        log "  Profile restored → $NIX_STORE_PATH"
-      else
-        log "  WARNING: Could not find nix binary in store — re-bootstrapping"
-        rm -f /nix/.bootstrapped
-        bootstrap_nix
-      fi
-    fi
+    log "Phase 2: Shared Nix store mounted but no profile at $KNIGHT_NIX_PROFILE yet (build pending)"
+  fi
+elif [ -d /nix ] && [ -w /nix ]; then
+  rt_bootstrap_nix
+  rt_restore_profile
+  if rt_source_nix; then
+    log "Phase 2: Nix ready — $(nix --version 2>/dev/null || echo 'binary found')"
   fi
 else
   log "Phase 2: No /nix mount — skipping Nix bootstrap"
-fi
-
-# Source Nix into PATH
-if [ -d "$NIX_PROFILE/bin" ]; then
-  export PATH="$NIX_PROFILE/bin:$PATH"
-  export NIX_CONF_DIR="/nix/etc/nix"
-  log "  Nix $(nix --version 2>/dev/null || echo 'binary found')"
 fi
 
 # ──────────────────────────────────────────────────────────────────
@@ -187,7 +113,9 @@ FLAKE_FILE="/config/flake.nix"
 NIX_ENV="/data/nix-env"
 HASH_FILE="/data/.nix-flake-hash"
 
-if [ -f "$FLAKE_FILE" ] && command -v nix >/dev/null 2>&1; then
+if [ "$NIX_SHARED_STORE" = "true" ]; then
+  log "Phase 3: Shared store — flake tools prebuilt by operator, skipping local build"
+elif [ -f "$FLAKE_FILE" ] && command -v nix >/dev/null 2>&1; then
   NEW_HASH=$(sha256sum "$FLAKE_FILE" | cut -d' ' -f1)
 
   if [ -f "$HASH_FILE" ] && [ "$(cat "$HASH_FILE")" = "$NEW_HASH" ] \

--- a/scripts/nix-build.sh
+++ b/scripts/nix-build.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# nix-build.sh — shared-store builder (runs in the operator's nix-build Job).
+#
+# Mounts the shared Nix store RW at /nix (one writer; knights mount it RO) and
+# the knight's ConfigMap at /config. Builds the knight's flake and publishes a
+# per-knight profile at /nix/var/nix/profiles/knights/<KNIGHT_NAME> that the
+# knight pod sources read-only.
+#
+# Store writes are serialized with a flock so concurrent per-knight build Jobs
+# can't race on the Nix SQLite db (single-user mode, no nix-daemon).
+#
+# Env:
+#   KNIGHT_NAME  — profile name to publish (required)
+#   FLAKE_FILE   — flake path (default /config/flake.nix)
+#   TMPDIR       — writable scratch (default /tmp); must NOT be on /nix (RO-safe)
+set -eo pipefail
+
+log() { echo "[nix-build] $(date '+%H:%M:%S') $*"; }
+
+KNIGHT_NAME="${KNIGHT_NAME:?KNIGHT_NAME is required}"
+FLAKE_FILE="${FLAKE_FILE:-/config/flake.nix}"
+LOCK_FILE="/nix/var/.roundtable-build.lock"
+PROFILE_DIR="/nix/var/nix/profiles/knights"
+PROFILE="$PROFILE_DIR/$KNIGHT_NAME"
+
+# shellcheck source=/dev/null
+. "$(dirname "$0")/nix-lib.sh"
+
+if [ ! -w /nix ]; then
+  log "ERROR: /nix is not writable — builder needs the store mounted RW"
+  exit 1
+fi
+if [ ! -f "$FLAKE_FILE" ]; then
+  log "ERROR: no flake at $FLAKE_FILE"
+  exit 1
+fi
+
+mkdir -p /nix/var "$PROFILE_DIR"
+
+# ── Critical section: serialize all store mutations across build Jobs ──
+exec 9>"$LOCK_FILE"
+log "Waiting for store lock..."
+flock 9
+log "Acquired store lock"
+
+rt_bootstrap_nix || { log "ERROR: bootstrap failed"; exit 1; }
+rt_restore_profile
+rt_source_nix || { log "ERROR: nix not on PATH after bootstrap"; exit 1; }
+log "Nix $(nix --version 2>/dev/null)"
+
+# Build the flake into the shared store. --print-out-paths gives the buildEnv
+# store path; we root it as the knight's profile so GC won't reap it.
+BUILD_DIR=$(mktemp -d)
+cp "$FLAKE_FILE" "$BUILD_DIR/flake.nix"
+
+log "Building flake for $KNIGHT_NAME..."
+if STORE_PATH=$(cd "$BUILD_DIR" && nix build ".#default" --no-link --print-out-paths 2>&1); then
+  STORE_PATH=$(echo "$STORE_PATH" | tail -1)
+else
+  log "ERROR: nix build failed:"
+  echo "$STORE_PATH" | tail -15
+  rm -rf "$BUILD_DIR"
+  exit 1
+fi
+rm -rf "$BUILD_DIR"
+
+if [ ! -d "$STORE_PATH/bin" ]; then
+  log "ERROR: build produced no bin/ at $STORE_PATH"
+  exit 1
+fi
+
+# Publish the profile (atomic symlink swap). Entries under .../profiles are GC
+# roots, so the closure is protected.
+ln -sfn "$STORE_PATH" "$PROFILE.tmp"
+mv -fT "$PROFILE.tmp" "$PROFILE"
+log "Published profile $PROFILE → $STORE_PATH ($(ls "$STORE_PATH/bin" | wc -l) tools)"

--- a/scripts/nix-lib.sh
+++ b/scripts/nix-lib.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# nix-lib.sh — shared Nix bootstrap helpers.
+#
+# Sourced by both entrypoint.sh (per-pod, read-write PVC) and nix-build.sh
+# (the shared-store builder Job). Keeping the bootstrap in one place stops the
+# two paths from drifting — historically a source of crashloop bugs.
+#
+# Expects: NIX_PROFILE (defaults to $HOME/.nix-profile). Operates on /nix.
+
+NIX_PROFILE="${NIX_PROFILE:-$HOME/.nix-profile}"
+NIX_CONF="/nix/etc/nix/nix.conf"
+
+# rt_log — namespaced logger; callers may override.
+rt_log() { echo "[nix-lib] $(date '+%H:%M:%S') $*"; }
+
+# rt_write_nix_conf — single-user nix.conf with the public binary cache so
+# tools substitute from cache.nixos.org instead of building from source.
+rt_write_nix_conf() {
+  mkdir -p /nix/etc/nix
+  cat > "$NIX_CONF" <<'EOF'
+build-users-group =
+experimental-features = nix-command flakes
+sandbox = false
+max-jobs = auto
+substituters = https://cache.nixos.org/
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+EOF
+}
+
+# rt_bootstrap_nix — install Nix into /nix from the image-cached installer
+# tarball if not already present. Idempotent. Returns non-zero on failure.
+rt_bootstrap_nix() {
+  if [ -f /nix/.bootstrapped ] && [ -d "$NIX_PROFILE/bin" ]; then
+    return 0
+  fi
+
+  rt_log "Installing Nix to PVC..."
+  mkdir -p /nix/store /nix/var/nix/profiles/per-user/node \
+           /nix/var/nix/gcroots/per-user/node /nix/etc/nix
+  rt_write_nix_conf
+
+  local cache_tar
+  cache_tar=$(ls /opt/nix-cache/nix-*.tar.xz 2>/dev/null | head -1)
+  if [ -z "$cache_tar" ]; then
+    rt_log "  ERROR: No cached Nix installer found"
+    return 1
+  fi
+
+  # Local var, NOT TMPDIR: overwriting the inherited TMPDIR and then rm-ing it
+  # leaves later mktemp calls pointing at a deleted base dir.
+  local installer_tmp
+  installer_tmp=$(mktemp -d)
+  rt_log "  Extracting installer..."
+  tar xf "$cache_tar" -C "$installer_tmp"
+
+  local installer_dir
+  installer_dir=$(find "$installer_tmp" -maxdepth 1 -name 'nix-*' -type d | head -1)
+  if [ -z "$installer_dir" ] || [ ! -d "$installer_dir/store" ]; then
+    rt_log "  ERROR: Unexpected installer layout in $installer_tmp"
+    rm -rf "$installer_tmp"
+    return 1
+  fi
+
+  rt_log "  Copying store paths..."
+  cp -a "$installer_dir/store/"* /nix/store/
+
+  local nix_store_path
+  nix_store_path=$(find /nix/store -maxdepth 1 -name '*-nix-*' -type d | grep -v '\.drv$' | head -1)
+  if [ -z "$nix_store_path" ] || [ ! -x "$nix_store_path/bin/nix" ]; then
+    nix_store_path=$(find /nix/store -name 'nix' -executable -path '*/bin/nix' -printf '%h/..\n' 2>/dev/null | head -1)
+    nix_store_path=$(cd "$nix_store_path" 2>/dev/null && pwd)
+  fi
+  if [ -z "$nix_store_path" ] || [ ! -x "$nix_store_path/bin/nix" ]; then
+    rt_log "  ERROR: Could not find nix binary in store"
+    rm -rf "$installer_tmp"
+    return 1
+  fi
+  rt_log "  Nix store path: $nix_store_path"
+
+  mkdir -p "$(dirname "$NIX_PROFILE")"
+  ln -sfn "$nix_store_path" "$NIX_PROFILE"
+  ln -sfn "$NIX_PROFILE" /nix/var/nix/profiles/per-user/node/profile
+
+  rm -rf "$installer_tmp"
+  touch /nix/.bootstrapped
+  rt_log "  Nix installed ✓ ($(du -sh /nix/store 2>/dev/null | cut -f1))"
+}
+
+# rt_restore_profile — repair a broken profile symlink on an already-bootstrapped
+# store (stale PVC / domain change). Re-bootstraps if the binary is gone.
+rt_restore_profile() {
+  if [ -d "$NIX_PROFILE/bin" ]; then
+    return 0
+  fi
+  rt_log "Profile symlink broken — restoring..."
+  local nix_store_path
+  nix_store_path=$(find /nix/store -maxdepth 1 -name '*-nix-*' -type d 2>/dev/null | grep -v '\.drv$' | head -1)
+  if [ -n "$nix_store_path" ] && [ -x "$nix_store_path/bin/nix" ]; then
+    mkdir -p "$(dirname "$NIX_PROFILE")"
+    ln -sfn "$nix_store_path" "$NIX_PROFILE"
+    rt_log "  Profile restored → $nix_store_path"
+  else
+    rt_log "  WARNING: nix binary missing — re-bootstrapping"
+    rm -f /nix/.bootstrapped
+    rt_bootstrap_nix
+  fi
+}
+
+# rt_source_nix — put Nix on PATH for the current shell.
+rt_source_nix() {
+  if [ -d "$NIX_PROFILE/bin" ]; then
+    export PATH="$NIX_PROFILE/bin:$PATH"
+    export NIX_CONF_DIR="/nix/etc/nix"
+    return 0
+  fi
+  return 1
+}


### PR DESCRIPTION
Foundation (1 of 3 repos) for replacing 25 per-knight 5Gi Nix PVCs (~125Gi allocated, ~2.2Gi each, almost all identical) with one RWX shared store: **one writer (the operator's build Job), many read-only readers (knights)**. Read-only consumers can't race or corrupt the store — Nix paths are immutable and content-addressed.

This PR is the pi-knight side; the roundtable-operator build Job and the dapper-cluster RWX PVC land separately. Nothing changes for running knights until the operator flips them to a read-only mount — and because this image already handles both mount modes, that cutover needs no further pi-knight release.

## Changes

- **`scripts/nix-lib.sh`** — bootstrap/profile/source helpers extracted from `entrypoint.sh` so the entrypoint and the builder share one implementation (drift between the two is what caused the #32 crashloop). Adds `cache.nixos.org` as a substituter so tools **download prebuilt instead of compiling from source** — the slow part of "Provisioning" (addresses optimization #2 from the review).
- **`scripts/nix-build.sh`** — runs in the operator's per-knight build Job. Mounts the shared store RW, serializes all store mutations with a `flock` (single-user Nix has no daemon, so concurrent builders must not race the store SQLite db), builds the knight's flake, and publishes `/nix/var/nix/profiles/knights/<name>`.
- **`entrypoint.sh`** — three Nix modes now:
  - `/nix` **read-only** → shared store; source the operator-published profile, skip bootstrap + local build
  - `/nix` **writable** → legacy per-pod PVC; bootstrap + build locally (now via `nix-lib`)
  - no `/nix` → skip
  Phase 3's local flake build is skipped on the shared store.

## Testing

`bash -n` clean on all three scripts. The writable-`/nix` path is behavior-preserving (same logic, now in `nix-lib`); the read-only path is new and inert until the operator mounts the shared store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)