### PR TITLE
fix: skip Nix installer re-copy when shared store already bootstrapped

### DIFF
--- a/scripts/nix-lib.sh
+++ b/scripts/nix-lib.sh
@@ -30,8 +30,16 @@ EOF
 # rt_bootstrap_nix — install Nix into /nix from the image-cached installer
 # tarball if not already present. Idempotent. Returns non-zero on failure.
 rt_bootstrap_nix() {
-  if [ -f /nix/.bootstrapped ] && [ -d "$NIX_PROFILE/bin" ]; then
-    return 0
+  # Fast path: the store is already populated (a warm per-pod PVC, or — the big
+  # one — the shared store every build Job mounts). A fresh build pod has an
+  # empty container HOME, so $NIX_PROFILE/bin is absent even though /nix is fully
+  # built; gating on it forced a full installer re-copy (cp -a of the store) on
+  # EVERY build pod, and on the shared store that re-copy runs inside the build
+  # lock, serially inflating every knight's critical section. Repairing the
+  # profile symlink via rt_restore_profile is a cheap, store-read-only operation.
+  if [ -f /nix/.bootstrapped ]; then
+    rt_restore_profile
+    return $?
   fi
 
   rt_log "Installing Nix to PVC..."


### PR DESCRIPTION
## Problem

During a fleet-wide rebuild (e.g. after a `nixpkgs.ref` bump rehashes all knights), every `<knight>-nixbuild` Job serializes on the shared-store flock. Each build pod has a fresh, empty container HOME, so `$NIX_PROFILE/bin` is absent even though the shared `/nix` store is fully populated. The old `rt_bootstrap_nix` guard gated its fast path on that symlink, so every pod fell through to a **full installer re-copy** (`cp -a` of the installer store paths into `/nix/store`) — and that re-copy happens **inside the build lock**, serially inflating every knight's critical section. Observed live: pods logging `Copying store paths...` while holding the lock; ~6–9 min lock-hold per knight; a 25-knight wave overrunning the 30-min job deadline.

## Fix

Gate the fast path on `/nix/.bootstrapped` alone. When the store is already bootstrapped, repair the per-container profile symlink via `rt_restore_profile` (a cheap, store-read-only relink that already locates the nix binary in the store) instead of re-copying the installer.

Strictly an improvement for both callers:
- **shared-store builder** (`nix-build.sh`): removes the `cp -a` from the lock's critical section.
- **legacy per-pod entrypoint**: a warm PVC with a broken profile symlink previously triggered a full re-copy; now it's a cheap relink. Fresh PVC still does the full install (marker absent).

No infinite recursion: `rt_restore_profile`'s missing-binary fallback `rm -f /nix/.bootstrapped` before recursing, so the fast path is skipped on the retry.