### PR TITLE
ci: run typecheck and unit tests before image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm test
       - run: npm run build
 
       - uses: docker/login-action@v3


### PR DESCRIPTION
Makes the build job a meaningful required check: fails on typecheck or unit test failures. Part of Night Watch phase 0.