### PR TITLE
feat: degraded state instead of crash-loop on preflight failure

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -7,12 +7,17 @@ import { handleIntrospect } from "./introspect.js";
 let server: http.Server | null = null;
 let skillCount = 0;
 let activeTaskCount = 0;
+let degradedReason: string | null = null;
 
 export function setSkillCount(n: number): void {
   skillCount = n;
 }
 export function setActiveTaskCount(n: number): void {
   activeTaskCount = n;
+}
+/** Mark the knight degraded (readiness 503 with reason) or recovered (null). */
+export function setDegradedReason(reason: string | null): void {
+  degradedReason = reason;
 }
 
 export function startHealthServer(config: KnightConfig): void {
@@ -32,11 +37,12 @@ export function startHealthServer(config: KnightConfig): void {
       );
     } else if (url === "/ready") {
       const nats = getNatsStatus();
-      const status = nats.connected ? 200 : 503;
-      res.writeHead(status, { "Content-Type": "application/json" });
+      const ready = nats.connected && degradedReason == null;
+      res.writeHead(ready ? 200 : 503, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
-          status: nats.connected ? "ready" : "not_ready",
+          status: ready ? "ready" : degradedReason != null ? "degraded" : "not_ready",
+          ...(degradedReason != null ? { degradedReason } : {}),
           nats: nats.connected ? "connected" : "disconnected",
           activeTasks: activeTaskCount,
           skillsLoaded: skillCount,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { loadConfig } from "./config.js";
 import { initLogger, log } from "./logger.js";
 import { connectNats, subscribe, publishResult, drain } from "./nats.js";
-import { startHealthServer, stopHealthServer, setSkillCount, setActiveTaskCount } from "./health.js";
+import { startHealthServer, stopHealthServer, setSkillCount, setActiveTaskCount, setDegradedReason } from "./health.js";
 import { loadSkills } from "@earendil-works/pi-coding-agent";
 import { executeTask, getActiveSession } from "./knight.js";
 import { startIntrospect } from "./introspect.js";
 import { resolveModel } from "./model.js";
-import { preflightModel } from "./preflight.js";
+import { preflightModelUntilReady } from "./preflight.js";
 import * as metrics from "./metrics.js";
 
 async function main(): Promise<void> {
@@ -24,11 +24,17 @@ async function main(): Promise<void> {
   log.info("Health server started", { port: config.metricsPort });
 
   // Preflight the model endpoint before doing anything else. For local endpoints
-  // (Ollama/LM Studio/LiteLLM) this fails fast on an unreachable endpoint or missing
+  // (Ollama/LM Studio/LiteLLM) this catches an unreachable endpoint or missing
   // model and warns on Ollama context-truncation footguns; cloud endpoints are a no-op.
+  // An unreachable endpoint used to exit fatally → CrashLoopBackOff; now the knight
+  // stays up and degraded (readiness 503 with the reason, /health still 200 so the
+  // startup probe passes) and retries with capped backoff until the endpoint answers.
   // Resolving here is throwaway (knight.ts re-resolves for the session) but shares the
   // same baseUrl/default logic, so what we probe is exactly what the session will use.
-  await preflightModel(resolveModel(config.knightModel).model);
+  await preflightModelUntilReady(resolveModel(config.knightModel).model, {
+    onAttemptFailed: (error) => setDegradedReason(`model preflight failed: ${error}`),
+  });
+  setDegradedReason(null);
 
   // Discover skills using Pi SDK's built-in agentskills.io loader
   // Retry for git-sync race at startup

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -71,6 +71,53 @@ export async function preflightModel(model: Model<Api>): Promise<void> {
   }
 }
 
+export interface PreflightRetryOptions {
+  /** First retry delay; doubles each failure. Default 5s. */
+  initialDelayMs?: number;
+  /** Backoff cap. Default 60s. */
+  maxDelayMs?: number;
+  /** Called on each failed attempt (drive health/degraded reporting from here). */
+  onAttemptFailed?: (error: string, attempt: number, nextDelayMs: number) => void;
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Preflight with in-process retry instead of a fatal throw.
+ *
+ * An unreachable local endpoint used to propagate out of main() and exit the
+ * process → CrashLoopBackOff. A knight that can't reach its model isn't broken,
+ * it's degraded: stay up, keep the health server answering, retry with capped
+ * exponential backoff, and only proceed (NATS connect → Ready) once the
+ * endpoint answers. Resolves when preflight passes; never rejects.
+ */
+export async function preflightModelUntilReady(
+  model: Model<Api>,
+  opts: PreflightRetryOptions = {},
+): Promise<void> {
+  const initialDelayMs = opts.initialDelayMs ?? 5_000;
+  const maxDelayMs = opts.maxDelayMs ?? 60_000;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  let delayMs = initialDelayMs;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await preflightModel(model);
+      return;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      opts.onAttemptFailed?.(msg, attempt, delayMs);
+      log.error("Model preflight failed — knight degraded, retrying", {
+        attempt,
+        retryInMs: delayMs,
+        error: msg,
+      });
+      await sleep(delayMs);
+      delayMs = Math.min(delayMs * 2, maxDelayMs);
+    }
+  }
+}
+
 /** Hit the OpenAI-compatible /models list: fatal if unreachable, warn if model absent. */
 async function checkReachableAndModel(baseUrl: string, model: Model<Api>): Promise<void> {
   let res: Response;

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { isLocalEndpoint, preflightModel } from "../src/preflight.ts";
+import { isLocalEndpoint, preflightModel, preflightModelUntilReady } from "../src/preflight.ts";
 
 /** Minimal Model stub — only the fields preflight reads matter. */
 function makeModel(overrides: Partial<Model<Api>>): Model<Api> {
@@ -146,6 +146,50 @@ test("preflightModel: num_ctx probe failure is non-fatal", async () => {
   });
   try {
     await preflightModel(makeModel({ id: "llama3.1" })); // must not reject
+  } finally {
+    restore();
+  }
+});
+
+test("preflightModelUntilReady: retries with backoff until the endpoint answers, never rejects", async () => {
+  let failuresLeft = 3;
+  const { restore } = stubFetch((url) => {
+    if (url.endsWith("/models")) {
+      if (failuresLeft > 0) {
+        failuresLeft--;
+        return "throw"; // unreachable endpoint
+      }
+      return { ok: true, json: () => ({ data: [{ id: "llama3.1" }] }) };
+    }
+    return { ok: true, json: () => ({}) };
+  });
+
+  const sleeps: number[] = [];
+  const failures: Array<{ attempt: number; error: string }> = [];
+  try {
+    await preflightModelUntilReady(makeModel({ id: "llama3.1" }), {
+      initialDelayMs: 10,
+      maxDelayMs: 25,
+      sleep: async (ms) => { sleeps.push(ms); },
+      onAttemptFailed: (error, attempt) => failures.push({ attempt, error }),
+    });
+  } finally {
+    restore();
+  }
+
+  assert.equal(failures.length, 3, "one onAttemptFailed per failed probe");
+  assert.ok(failures.every((f) => f.error.includes("unreachable")), "reason carries the preflight error");
+  assert.deepEqual(sleeps, [10, 20, 25], "exponential backoff capped at maxDelayMs");
+});
+
+test("preflightModelUntilReady: cloud endpoint resolves immediately with no retries", async () => {
+  const { calls, restore } = stubFetch(() => ({ ok: true }));
+  try {
+    await preflightModelUntilReady(
+      makeModel({ provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1" }),
+      { sleep: async () => { assert.fail("must not sleep"); } },
+    );
+    assert.equal(calls.length, 0);
   } finally {
     restore();
   }


### PR DESCRIPTION
## What

An unreachable local model endpoint (the seven-ollama-knights incident, §3 of the work ledger) previously threw out of `main()` → `process.exit(1)` → CrashLoopBackOff. Now the knight:

- stays up, `/health` keeps returning 200 so the startup probe passes
- reports readiness **503 with `status: "degraded"` and a `degradedReason`** (`model preflight failed: Model endpoint unreachable at …`) — visible in Fleet and to the dashboard API instead of a bare CrashLoopBackOff
- retries the preflight in-process with capped exponential backoff (5s → 60s)
- proceeds to NATS connect (→ Ready) only once the endpoint answers — recovery is automatic when the endpoint comes back, no pod restart needed

Cloud endpoints unchanged: preflight remains a no-op for them, `preflightModelUntilReady` resolves immediately.

Composes with roundtable-ui#146: a degraded knight now answers its readiness/introspect endpoints instead of being an unreachable crash-looping pod.

## Tests

- `preflightModelUntilReady: retries with backoff until the endpoint answers, never rejects` (verifies backoff sequence 10→20→25-capped and per-attempt degraded callbacks)
- `preflightModelUntilReady: cloud endpoint resolves immediately with no retries`

`mise run runtime:test` 38/38, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)