### PR TITLE
fix: extract real message content in session introspect

### DIFF
--- a/src/introspect-format.ts
+++ b/src/introspect-format.ts
@@ -1,0 +1,122 @@
+// Pure formatting helpers that turn raw pi-ai session entries into the compact
+// items the dashboard's Session Explorer renders. Kept side-effect free (no
+// NATS/knight imports) so they can be unit-tested in isolation.
+//
+// Data model (from @earendil-works/pi-ai). A session entry of type "message"
+// carries `message: UserMessage | AssistantMessage | ToolResultMessage`:
+//   - UserMessage:       role "user",       content: string | (TextContent | ImageContent)[]
+//   - AssistantMessage:  role "assistant",  content: (TextContent | ThinkingContent | ToolCall)[], usage: Usage
+//   - ToolResultMessage: role "toolResult", toolName, content: (TextContent | ImageContent)[], isError
+// where TextContent = { type: "text", text }, ToolCall = { type: "toolCall", id, name, arguments },
+// and Usage = { input, output, cost: { total, ... } }.
+
+// Extract a short text preview from any pi-ai message content: a raw string, or
+// an array of content blocks (we keep the `text` blocks). Tool arguments and
+// tool-result payloads are surfaced separately as their own fields.
+export function previewText(content: unknown, max = 500): string {
+  if (typeof content === "string") return content.slice(0, max);
+  if (Array.isArray(content)) {
+    return content
+      .filter(
+        (b): b is { type: "text"; text: string } =>
+          !!b && typeof b === "object" && (b as any).type === "text" && typeof (b as any).text === "string",
+      )
+      .map((b) => b.text)
+      .join("\n")
+      .slice(0, max);
+  }
+  return "";
+}
+
+// Map one session entry to its display item(s). A message may expand to more
+// than one item: an assistant message yields the assistant entry plus a
+// tool_use entry per tool call.
+export function recentItemsForEntry(entry: any): Record<string, unknown>[] {
+  const base: Record<string, unknown> = {
+    id: entry.id,
+    parentId: entry.parentId,
+    type: entry.type,
+    timestamp: entry.timestamp,
+  };
+
+  if (entry.type !== "message" || !entry.message) {
+    return [base];
+  }
+
+  const msg = entry.message;
+  base.role = msg.role;
+
+  if (msg.role === "toolResult") {
+    // A tool result is its own message in pi-ai (role "toolResult"), with the
+    // returned content in `content` and the tool in `toolName`. Present it as a
+    // tool_result entry so the timeline + Tools view show what came back.
+    base.type = "tool_result";
+    base.toolName = msg.toolName ?? null;
+    const out = previewText(msg.content);
+    base.output = out;
+    base.text = msg.isError ? `⚠ ${out}` : out;
+    return [base];
+  }
+
+  if (msg.role === "user") {
+    base.text = previewText(msg.content);
+    return [base];
+  }
+
+  if (msg.role === "assistant") {
+    // AssistantMessage.content: (TextContent | ThinkingContent | ToolCall)[].
+    // Tool calls are `type: "toolCall"` with `name`/`arguments`.
+    const textParts: string[] = [];
+    const toolEntries: Record<string, unknown>[] = [];
+    if (Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (!block || typeof block !== "object") continue;
+        if (block.type === "text" && typeof block.text === "string") {
+          textParts.push(block.text);
+        } else if (block.type === "toolCall") {
+          toolEntries.push({
+            id: `${entry.id}-tc-${block.id ?? toolEntries.length}`,
+            parentId: entry.parentId,
+            type: "tool_use",
+            timestamp: entry.timestamp,
+            role: "assistant",
+            toolName: block.name,
+            input: JSON.stringify(block.arguments ?? {}).slice(0, 500),
+          });
+        }
+      }
+    }
+    if (textParts.length > 0) base.text = textParts.join("\n").slice(0, 500);
+
+    // pi-ai Usage: token counts under input/output, cost under cost.total.
+    const u = msg.usage;
+    if (u && typeof u === "object") {
+      base.tokens = { input: u.input ?? 0, output: u.output ?? 0 };
+      if (u.cost && typeof u.cost.total === "number") base.cost = u.cost.total;
+    }
+
+    return [base, ...toolEntries];
+  }
+
+  // Unknown/custom role — still surface any text we can find.
+  base.text = previewText(msg.content);
+  return [base];
+}
+
+// One-line summary for the tree view.
+export function summarizeEntry(entry: any): string {
+  if (entry.type !== "message" || !entry.message) return entry.type;
+  const msg = entry.message;
+  if (msg.role === "toolResult") {
+    const tool = msg.toolName ? `${msg.toolName} → ` : "toolResult: ";
+    return `${tool}${previewText(msg.content, 100)}`;
+  }
+  if (msg.role === "assistant") {
+    const text = previewText(msg.content, 100);
+    const tools = Array.isArray(msg.content)
+      ? msg.content.filter((b: any) => b?.type === "toolCall").map((b: any) => b.name)
+      : [];
+    return text ? `assistant: ${text}` : tools.length ? `assistant → ${tools.join(", ")}` : "assistant";
+  }
+  return `${msg.role}: ${previewText(msg.content, 100)}`;
+}

--- a/src/introspect.ts
+++ b/src/introspect.ts
@@ -1,6 +1,7 @@
 import { log } from "./logger.js";
 import { getConnection } from "./nats.js";
 import { getActiveSession } from "./knight.js";
+import { recentItemsForEntry, summarizeEntry } from "./introspect-format.js";
 import type { KnightConfig } from "./config.js";
 import type { Subscription } from "nats";
 import { StringCodec } from "./nats.js";
@@ -108,95 +109,13 @@ function buildRecent(config: KnightConfig, limit: number) {
   const entries = session.sessionManager.getEntries();
   const recent = entries.slice(-limit);
 
-  const items = recent.map((entry) => {
-    const base: Record<string, unknown> = {
-      id: entry.id,
-      parentId: entry.parentId,
-      type: entry.type,
-      timestamp: entry.timestamp,
-    };
-
-    if (entry.type === "message") {
-      const msg = entry.message;
-      base.role = msg.role;
-
-      if (msg.role === "user" || msg.role === "assistant") {
-        const content = msg.content;
-        if (typeof content === "string") {
-          base.text = content.slice(0, 500);
-        } else if (Array.isArray(content)) {
-          // Collect all text blocks, then generate separate entries for tool_use/tool_result
-          const textParts: string[] = [];
-          const toolEntries: Record<string, unknown>[] = [];
-
-          for (const block of content) {
-            if (typeof block === "object" && block !== null) {
-              if ("text" in block && typeof block.text === "string") {
-                textParts.push(block.text);
-              }
-              if ("type" in block && (block as any).type === "tool_use") {
-                toolEntries.push({
-                  id: `${entry.id}-tu-${(block as any).id ?? toolEntries.length}`,
-                  parentId: entry.parentId,
-                  type: "tool_use",
-                  timestamp: entry.timestamp,
-                  role: msg.role,
-                  toolName: (block as any).name,
-                  input: JSON.stringify((block as any).input ?? {}).slice(0, 500),
-                });
-              }
-              if ("type" in block && (block as any).type === "tool_result") {
-                toolEntries.push({
-                  id: `${entry.id}-tr-${toolEntries.length}`,
-                  parentId: entry.parentId,
-                  type: "tool_result",
-                  timestamp: entry.timestamp,
-                  role: msg.role,
-                  toolName: (block as any).tool_use_id,
-                  output: JSON.stringify((block as any).content ?? "").slice(0, 500),
-                });
-              }
-            }
-          }
-
-          if (textParts.length > 0) {
-            base.text = textParts.join("\n").slice(0, 500);
-          }
-          // Attach extra entries for tool blocks (picked up after map)
-          if (toolEntries.length > 0) {
-            (base as any)._extraEntries = toolEntries;
-          }
-        }
-      }
-
-      // Extract usage/cost if present
-      if ("usage" in msg && msg.usage) {
-        const u = msg.usage as any;
-        base.tokens = { input: u.inputTokens ?? 0, output: u.outputTokens ?? 0 };
-      }
-      if ("cost" in msg && typeof msg.cost === "number") {
-        base.cost = msg.cost;
-      }
-    }
-
-    return base;
-  });
-
-  // Flatten: expand _extraEntries into the items list
-  const flatItems: Record<string, unknown>[] = [];
-  for (const item of items) {
-    flatItems.push(item);
-    if ((item as any)._extraEntries) {
-      flatItems.push(...(item as any)._extraEntries);
-      delete (item as any)._extraEntries;
-    }
-  }
+  const flatItems = recent.flatMap((entry) => recentItemsForEntry(entry));
 
   return {
     knight: config.knightName,
     entries: flatItems,
     total: entries.length,
-    returned: items.length,
+    returned: recent.length,
   };
 }
 
@@ -215,25 +134,7 @@ function buildTree(config: KnightConfig) {
     };
 
     if (node.label) base.label = node.label;
-
-    // Brief summary
-    if (entry.type === "message" && entry.message) {
-      const msg = entry.message;
-      let text = "";
-      if (typeof msg.content === "string") {
-        text = msg.content.slice(0, 100);
-      } else if (Array.isArray(msg.content)) {
-        for (const block of msg.content) {
-          if (typeof block === "object" && block !== null && "text" in block) {
-            text = (block.text as string).slice(0, 100);
-            break;
-          }
-        }
-      }
-      base.summary = `${msg.role}: ${text}`;
-    } else {
-      base.summary = entry.type;
-    }
+    base.summary = summarizeEntry(entry);
 
     return base;
   }

--- a/tests/introspect-format.test.ts
+++ b/tests/introspect-format.test.ts
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { previewText, recentItemsForEntry, summarizeEntry } from "../src/introspect-format.ts";
+
+// Shapes below mirror @earendil-works/pi-ai 0.79.1 exactly (verified against a
+// live agravain session): assistant tool calls are `type: "toolCall"` blocks;
+// tool results are their own `role: "toolResult"` messages; usage lives under
+// `usage.input/output` and `usage.cost.total`.
+
+const ts = "2026-07-08T06:05:35Z";
+
+function entry(id: string, message: unknown) {
+  return { id, parentId: null, type: "message", timestamp: ts, message };
+}
+
+test("assistant text message surfaces its text and real token/cost fields", () => {
+  const items = recentItemsForEntry(
+    entry("a1", {
+      role: "assistant",
+      content: [{ type: "text", text: "Let me research current events." }],
+      usage: { input: 1200, output: 340, cost: { total: 0.0123 } },
+    }),
+  );
+  assert.equal(items.length, 1);
+  assert.equal(items[0].type, "message");
+  assert.equal(items[0].text, "Let me research current events.");
+  assert.deepEqual(items[0].tokens, { input: 1200, output: 340 });
+  assert.equal(items[0].cost, 0.0123);
+});
+
+test("assistant tool-call message expands into tool_use entries with args", () => {
+  const items = recentItemsForEntry(
+    entry("a2", {
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: "tc_1", name: "write_file", arguments: { path: "/vault/x.json", bytes: 1654 } },
+      ],
+      usage: { input: 50, output: 10, cost: { total: 0.001 } },
+    }),
+  );
+  assert.equal(items.length, 2, "assistant shell + one tool_use");
+  const tool = items[1];
+  assert.equal(tool.type, "tool_use");
+  assert.equal(tool.toolName, "write_file");
+  assert.equal(tool.input, JSON.stringify({ path: "/vault/x.json", bytes: 1654 }));
+  assert.equal(tool.id, "a2-tc-tc_1");
+});
+
+test("toolResult message becomes a tool_result entry with the returned content", () => {
+  const items = recentItemsForEntry(
+    entry("t1", {
+      role: "toolResult",
+      toolName: "write_file",
+      isError: false,
+      content: [{ type: "text", text: "Successfully wrote 1654 bytes to /vault/Briefings/Ledger/intel.json" }],
+    }),
+  );
+  assert.equal(items.length, 1);
+  assert.equal(items[0].type, "tool_result");
+  assert.equal(items[0].toolName, "write_file");
+  assert.equal(items[0].output, "Successfully wrote 1654 bytes to /vault/Briefings/Ledger/intel.json");
+  assert.equal(items[0].text, "Successfully wrote 1654 bytes to /vault/Briefings/Ledger/intel.json");
+});
+
+test("errored tool result is flagged in the preview text", () => {
+  const [item] = recentItemsForEntry(
+    entry("t2", { role: "toolResult", toolName: "bash", isError: true, content: [{ type: "text", text: "command not found" }] }),
+  );
+  assert.equal(item.text, "⚠ command not found");
+});
+
+test("user message string content is surfaced", () => {
+  const [item] = recentItemsForEntry(entry("u1", { role: "user", content: "Generate today's intelligence digest." }));
+  assert.equal(item.role, "user");
+  assert.equal(item.text, "Generate today's intelligence digest.");
+});
+
+test("non-message entries pass through untouched", () => {
+  const items = recentItemsForEntry({ id: "m1", parentId: null, type: "model_change", timestamp: ts, provider: "anthropic", modelId: "claude-opus-4-8" });
+  assert.equal(items.length, 1);
+  assert.equal(items[0].type, "model_change");
+  assert.equal(items[0].text, undefined);
+});
+
+test("previewText keeps only text blocks and clamps length", () => {
+  assert.equal(previewText([{ type: "text", text: "hello" }, { type: "toolCall", name: "x" }]), "hello");
+  assert.equal(previewText("x".repeat(600)).length, 500);
+  assert.equal(previewText(undefined), "");
+});
+
+test("summarizeEntry labels tool calls and results by tool name", () => {
+  assert.equal(
+    summarizeEntry(entry("t", { role: "toolResult", toolName: "list_dir", content: [{ type: "text", text: "-rw-r--r-- intel.json" }] })),
+    "list_dir → -rw-r--r-- intel.json",
+  );
+  assert.equal(
+    summarizeEntry(entry("a", { role: "assistant", content: [{ type: "toolCall", name: "search_web", arguments: {} }] })),
+    "assistant → search_web",
+  );
+  assert.equal(
+    summarizeEntry(entry("a", { role: "assistant", content: [{ type: "text", text: "thinking out loud" }] })),
+    "assistant: thinking out loud",
+  );
+});


### PR DESCRIPTION
## Problem

The Session Explorer timeline rendered empty rows (after roundtable-ui#148 made
them legible, they showed as `toolResult message` / `assistant message` with no
content, `0t` tokens, no cost). Root cause: `introspect.ts` `buildRecent` was
written against the **Anthropic wire format**, but pi-knight's session uses the
`@earendil-works/pi-ai` `AgentMessage` model.

Verified against a live `agravain` session (`/api/fleet/agravain/session?type=recent`):
every entry came back `type: "message"` with empty `text`/`output`, `toolName: null`,
`tokens: {0,0}`, `cost: null`.

### The mismatches
| Concept | Code assumed (Anthropic) | Actual (pi-ai 0.79.1) |
|---|---|---|
| Tool call | `type:"tool_use"`, `input`, in assistant content | `type:"toolCall"`, `name`, `arguments` |
| Tool result | `type:"tool_result"` content block, `tool_use_id` | its own `role:"toolResult"` message, `toolName`, `content[]` |
| Tokens | `usage.inputTokens/outputTokens` | `usage.input/output` |
| Cost | `msg.cost` | `usage.cost.total` |

The `role === "user" || "assistant"` guard also skipped every `toolResult`
message outright. (The tree view only "worked" by accidentally grabbing the
first `text` block from any content.)

## Fix

- Rewrite the entry→item mapping against the real pi-ai types: `toolResult` →
  `tool_result` entry with `output`/`text`; assistant `toolCall` blocks →
  `tool_use` entries with `name`/`arguments`; correct token & cost fields.
- Apply the same model to `buildTree` summaries (label tool calls/results by
  tool name).
- Extract the pure formatters into `introspect-format.ts` and add unit tests
  covering each message shape (8 tests; full suite 46/46 green).

No API/response-schema change — same field names the dashboard already reads,
now actually populated.