### PR TITLE
feat: session history browsing in introspect (history + session)

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -52,9 +52,15 @@ export function startHealthServer(config: KnightConfig): void {
       );
     } else if (url === "/introspect" || url?.startsWith("/introspect?")) {
       const urlObj = new URL(url, "http://localhost");
-      const type = (urlObj.searchParams.get("type") ?? "stats") as "stats" | "recent" | "tree";
+      const type = (urlObj.searchParams.get("type") ?? "stats") as
+        | "stats"
+        | "recent"
+        | "tree"
+        | "history"
+        | "session";
       const limit = parseInt(urlObj.searchParams.get("limit") ?? "20", 10);
-      const result = handleIntrospect({ type, limit }, config);
+      const id = urlObj.searchParams.get("id") ?? undefined;
+      const result = await handleIntrospect({ type, limit, id }, config);
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(result, null, 2));
     } else if (url === "/metrics") {

--- a/src/introspect-format.ts
+++ b/src/introspect-format.ts
@@ -103,6 +103,48 @@ export function recentItemsForEntry(entry: any): Record<string, unknown>[] {
   return [base];
 }
 
+// A persisted session file is JSONL: an optional `{type:"session",...}` header
+// line followed by one SessionTreeEntry per line. Parse into header + entries.
+export function parseSessionFile(contents: string): { header: any | null; entries: any[] } {
+  let header: any | null = null;
+  const entries: any[] = [];
+  for (const line of contents.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj: any;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      continue; // skip malformed/partial lines
+    }
+    if (obj && obj.type === "session") {
+      header = obj;
+    } else if (obj) {
+      entries.push(obj);
+    }
+  }
+  return { header, entries };
+}
+
+// Compact metadata for the session-history list. `id`/`sizeBytes` come from the
+// file; everything else is derived from the parsed contents.
+export function summarizeSession(
+  parsed: { header: any | null; entries: any[] },
+  meta: { id: string; sizeBytes?: number },
+): Record<string, unknown> {
+  const { header, entries } = parsed;
+  const messages = entries.filter((e) => e.type === "message");
+  const firstUser = messages.find((e) => e.message?.role === "user");
+  return {
+    id: meta.id,
+    startedAt: header?.timestamp ?? entries[0]?.timestamp ?? null,
+    entryCount: entries.length,
+    messageCount: messages.length,
+    firstPrompt: firstUser ? previewText(firstUser.message?.content, 140) : "",
+    sizeBytes: meta.sizeBytes ?? null,
+  };
+}
+
 // One-line summary for the tree view.
 export function summarizeEntry(entry: any): string {
   if (entry.type !== "message" || !entry.message) return entry.type;

--- a/src/introspect.ts
+++ b/src/introspect.ts
@@ -1,7 +1,14 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
 import { log } from "./logger.js";
 import { getConnection } from "./nats.js";
 import { getActiveSession } from "./knight.js";
-import { recentItemsForEntry, summarizeEntry } from "./introspect-format.js";
+import {
+  parseSessionFile,
+  recentItemsForEntry,
+  summarizeEntry,
+  summarizeSession,
+} from "./introspect-format.js";
 import type { KnightConfig } from "./config.js";
 import type { Subscription } from "nats";
 import { StringCodec } from "./nats.js";
@@ -9,12 +16,23 @@ import { StringCodec } from "./nats.js";
 const sc = StringCodec();
 
 interface IntrospectRequest {
-  type: "stats" | "recent" | "tree";
+  type: "stats" | "recent" | "tree" | "history" | "session";
   limit?: number;
+  offset?: number;
+  id?: string;
 }
 
 const startTime = Date.now();
 let sub: Subscription | null = null;
+
+// Root of the persisted per-session JSONL files (pi SDK writes under
+// <agentDir>/sessions; knights use agentDir "/data"). Overridable for tests.
+const SESSIONS_ROOT = process.env.KNIGHT_SESSIONS_ROOT ?? "/data/sessions";
+// Cap how many past sessions we list and how many entries we page per request
+// (keeps the NATS reply under the ~1MB payload limit).
+const MAX_HISTORY = 60;
+const MAX_SESSION_ENTRIES = 500;
+const DEFAULT_SESSION_ENTRIES = 200;
 
 export function startIntrospect(config: KnightConfig): void {
   const nc = getConnection();
@@ -39,7 +57,7 @@ export function startIntrospect(config: KnightConfig): void {
           // default to stats
         }
 
-        const response = handleIntrospect(req, config);
+        const response = await handleIntrospect(req, config);
         msg.respond(sc.encode(JSON.stringify(response)));
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
@@ -50,7 +68,16 @@ export function startIntrospect(config: KnightConfig): void {
   })();
 }
 
-export function handleIntrospect(req: IntrospectRequest, config: KnightConfig): unknown {
+export async function handleIntrospect(req: IntrospectRequest, config: KnightConfig): Promise<unknown> {
+  // History browsing reads persisted JSONL files and works regardless of
+  // whether an in-memory session is currently active.
+  if (req.type === "history") {
+    return buildHistory(config);
+  }
+  if (req.type === "session") {
+    return buildSession(config, req.id, req.limit, req.offset);
+  }
+
   const session = getActiveSession();
 
   if (!session) {
@@ -155,5 +182,94 @@ function buildTree(config: KnightConfig) {
     knight: config.knightName,
     nodes: flattenTree(tree),
     totalNodes: flattenTree(tree).length,
+  };
+}
+
+// A persisted session's public id is the uuid embedded in its filename
+// (`<iso-timestamp>_<uuid>.jsonl`). Validate ids to this charset so a request
+// can never escape the sessions dir.
+const SESSION_ID_RE = /^[0-9a-fA-F-]+$/;
+
+function sessionIdFromFilename(name: string): string {
+  const stem = name.replace(/\.jsonl$/, "");
+  const us = stem.lastIndexOf("_");
+  return us >= 0 ? stem.slice(us + 1) : stem;
+}
+
+// List every persisted session file under the sessions root (one subdir per
+// cwd), newest first by mtime. Returns [] if the dir doesn't exist yet.
+async function listSessionFiles(): Promise<Array<{ id: string; path: string; sizeBytes: number; mtimeMs: number }>> {
+  let dirents;
+  try {
+    dirents = await readdir(SESSIONS_ROOT, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const dirs = dirents.filter((d) => d.isDirectory()).map((d) => join(SESSIONS_ROOT, d.name));
+  // Defensive: also consider .jsonl files sitting directly in the root.
+  if (dirents.some((d) => d.isFile() && d.name.endsWith(".jsonl"))) dirs.push(SESSIONS_ROOT);
+
+  const files: Array<{ id: string; path: string; sizeBytes: number; mtimeMs: number }> = [];
+  for (const dir of dirs) {
+    let names;
+    try {
+      names = await readdir(dir);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (!name.endsWith(".jsonl")) continue;
+      const path = join(dir, name);
+      try {
+        const st = await stat(path);
+        files.push({ id: sessionIdFromFilename(name), path, sizeBytes: st.size, mtimeMs: st.mtimeMs });
+      } catch {
+        // file vanished between readdir and stat — skip
+      }
+    }
+  }
+  files.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return files;
+}
+
+async function buildHistory(config: KnightConfig) {
+  const files = await listSessionFiles();
+  const sessions = [];
+  for (const f of files.slice(0, MAX_HISTORY)) {
+    try {
+      const parsed = parseSessionFile(await readFile(f.path, "utf8"));
+      sessions.push(summarizeSession(parsed, { id: f.id, sizeBytes: f.sizeBytes }));
+    } catch {
+      // unreadable file — skip rather than fail the whole listing
+    }
+  }
+  return { knight: config.knightName, sessions, total: files.length };
+}
+
+async function buildSession(config: KnightConfig, id: string | undefined, limit?: number, offset?: number) {
+  if (!id || !SESSION_ID_RE.test(id)) {
+    return { error: "Invalid or missing session id" };
+  }
+  const files = await listSessionFiles();
+  const file = files.find((f) => f.id === id);
+  if (!file) {
+    return { error: `Session not found: ${id}` };
+  }
+
+  const { header, entries } = parseSessionFile(await readFile(file.path, "utf8"));
+  const start = Math.max(0, offset ?? 0);
+  const count = Math.min(Math.max(1, limit ?? DEFAULT_SESSION_ENTRIES), MAX_SESSION_ENTRIES);
+  const page = entries.slice(start, start + count);
+  const items = page.flatMap((entry) => recentItemsForEntry(entry));
+
+  return {
+    knight: config.knightName,
+    id,
+    startedAt: header?.timestamp ?? entries[0]?.timestamp ?? null,
+    entries: items,
+    total: entries.length,
+    offset: start,
+    returned: page.length,
+    hasMore: start + page.length < entries.length,
   };
 }

--- a/tests/introspect-format.test.ts
+++ b/tests/introspect-format.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { previewText, recentItemsForEntry, summarizeEntry } from "../src/introspect-format.ts";
+import { parseSessionFile, previewText, recentItemsForEntry, summarizeEntry, summarizeSession } from "../src/introspect-format.ts";
 
 // Shapes below mirror @earendil-works/pi-ai 0.79.1 exactly (verified against a
 // live agravain session): assistant tool calls are `type: "toolCall"` blocks;
@@ -86,6 +86,37 @@ test("previewText keeps only text blocks and clamps length", () => {
   assert.equal(previewText([{ type: "text", text: "hello" }, { type: "toolCall", name: "x" }]), "hello");
   assert.equal(previewText("x".repeat(600)).length, 500);
   assert.equal(previewText(undefined), "");
+});
+
+test("parseSessionFile splits the session header from entries and skips junk", () => {
+  const jsonl = [
+    JSON.stringify({ type: "session", version: 3, id: "abc", timestamp: "2026-07-08T11:00:00Z", cwd: "/data" }),
+    JSON.stringify({ type: "model_change", id: "m1", timestamp: "2026-07-08T11:00:00Z" }),
+    "",
+    "{ truncated partial line",
+    JSON.stringify({ type: "message", id: "u1", timestamp: "2026-07-08T11:00:01Z", message: { role: "user", content: "hi" } }),
+  ].join("\n");
+  const { header, entries } = parseSessionFile(jsonl);
+  assert.equal(header.id, "abc");
+  assert.equal(entries.length, 2, "model_change + message, junk/blank skipped");
+});
+
+test("summarizeSession derives counts and the first user prompt", () => {
+  const parsed = parseSessionFile(
+    [
+      JSON.stringify({ type: "session", id: "s1", timestamp: "2026-07-08T11:00:00Z" }),
+      JSON.stringify({ type: "model_change", id: "m1", timestamp: "2026-07-08T11:00:00Z" }),
+      JSON.stringify({ type: "message", id: "u1", timestamp: "2026-07-08T11:00:01Z", message: { role: "user", content: [{ type: "text", text: "Generate today's digest" }] } }),
+      JSON.stringify({ type: "message", id: "a1", timestamp: "2026-07-08T11:00:02Z", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } }),
+    ].join("\n"),
+  );
+  const meta = summarizeSession(parsed, { id: "s1", sizeBytes: 1234 });
+  assert.equal(meta.id, "s1");
+  assert.equal(meta.startedAt, "2026-07-08T11:00:00Z");
+  assert.equal(meta.entryCount, 3);
+  assert.equal(meta.messageCount, 2);
+  assert.equal(meta.firstPrompt, "Generate today's digest");
+  assert.equal(meta.sizeBytes, 1234);
 });
 
 test("summarizeEntry labels tool calls and results by tool name", () => {


### PR DESCRIPTION
## What

Adds two file-backed introspect request types so the dashboard can **browse and replay past sessions**, not just the live one.

Every knight already persists sessions as append-only JSONL on its `/data` PVC (`/data/sessions/--data--/<ts>_<uuid>.jsonl`) — this exposes them:

- **`history`** → lists past sessions `[{id, startedAt, entryCount, messageCount, firstPrompt, sizeBytes}]`, newest first, capped at 60.
- **`session`** (`{id, limit?, offset?}`) → reads one session's JSONL, paginated (default 200, cap 500 raw entries), mapped through the existing `recentItemsForEntry` so replay renders identically to the live timeline.

## Notes

- `handleIntrospect` is now `async` (file I/O); the local `/introspect` debug endpoint + health handler updated to `await`.
- Session ids validated to the uuid charset — a request can never escape the sessions dir (verified: `../etc/passwd` → rejected).
- Pure parsers (`parseSessionFile`, `summarizeSession`) live in `introspect-format.ts` with unit tests.
- Sessions root overridable via `KNIGHT_SESSIONS_ROOT` (tests + local runs).

## Verification

- Full suite **48/48** (10 introspect-format tests). Typecheck clean.
- Drove `handleIntrospect` against **real session files** pulled from the agravain pod: `history` listed 3 sessions with correct counts/prompts; `session` paginated a 236-entry session (`total=236, hasMore=true`) with real tool calls/results; guards rejected traversal + unknown ids.

Part 1 of the session-replay feature (v1 = per-knight on-demand). Paired with a `roundtable-ui` PR adding the API passthrough + Session Explorer picker.

Follow-up (not in v1): retention/pruning of old session files (currently unbounded — ~13 MB/89 files on agravain).